### PR TITLE
Change test compilation on ARM due to incompatibilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,11 @@ static_assertions = "1.1.0"
 
 [dev-dependencies]
 sha3 = "0.10"
-criterion-cycles-per-byte = "0.4"
 criterion = { version = "0.4", features = ["html_reports"] }
+cfg-if = "1.0.0"
+
+[target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dev-dependencies]
+criterion-cycles-per-byte = { version = "0.4" }
 
 [[bench]]
 name = "lthash16_performance"


### PR DESCRIPTION
<!-- Please explain the changes you made -->
Dev-dependencies and benches required to use `criterion_cycles_per_byte` which is only compatible with x86/x86_64 architectures. This PR fixes it by using default measurement for non x86/x86_64 architectures.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/runtime-machines/lthash-rs/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/runtime-machines/lthash-rs/blob/main/CHANGELOG.md
-->
